### PR TITLE
Added handeling for steam activation return code 14 (Invalid Key)

### DIFF
--- a/activator.d
+++ b/activator.d
@@ -114,6 +114,10 @@ void activateSteamKeys(SteamKey[] steamKeys)
 					stderr.writeln("\t", "Already have this product");
 					File(resultFile, "a").writefln!"%s\t%s\t%s"(key.key, "Already owned", key.name);
 					break;
+				case 14:
+					stderr.writeln("\t", "Invalid key");
+					File(resultFile, "a").writefln!"%s\t%s\t%s"(key.key, "Invalid key", key.name);
+					break;
 				case 24:
 					stderr.writeln("\t", "Need another product");
 					File(resultFile, "a").writefln!"%s\t%s\t%s"(key.key, "Need another", key.name);


### PR DESCRIPTION
Hi,

While using the tool I triped on an unknown error (return code 14) in the steam activation part, after investigation, it seem to be an error for an invalid and/or (most probably) expired key.